### PR TITLE
Support Python virtual environments in configure and initialisation

### DIFF
--- a/pyffi-lib/pyffi/configure-pyffi.rkt
+++ b/pyffi-lib/pyffi/configure-pyffi.rkt
@@ -216,6 +216,14 @@
        (newline)
        (displayln system-configuration-string))]))
 
+(define (run-python-query path-to-python code)
+  (define str-path (if (path? path-to-python)
+                       (path->string path-to-python)
+                       (or path-to-python "python3")))
+  (define cmd (string-append str-path " -c " (format "~s" code)))
+  (define out (with-output-to-string (λ () (system cmd))))
+  (string-trim out))
+
 (define (handle-data path-to-python)
   (cond
     [(python-data) => set-new-data]
@@ -227,11 +235,48 @@
        (newline)
        (displayln system-configuration-string))]))
 
+(define (set-new-home new-home)
+  (put-preferences (list 'pyffi:home) (list new-home))
+  (displayln "The preference for PYTHONHOME is now set to:")
+  (display   "    ")
+  (displayln new-home))
+
+(define (set-new-pyver new-pyver)
+  (put-preferences (list 'pyffi:pyver) (list new-pyver))
+  (displayln "The preference for Python version is now set to:")
+  (display   "    ")
+  (displayln new-pyver))
+
+(define (set-new-venv new-venv)
+  (put-preferences (list 'pyffi:venv) (list new-venv))
+  (displayln "The preference for venv path is now set to:")
+  (display   "    ")
+  (displayln new-venv))
+
+(define (set-new-platlibdir new-platlibdir)
+  (put-preferences (list 'pyffi:platlibdir) (list new-platlibdir))
+  (displayln "The preference for platlibdir is now set to:")
+  (display   "    ")
+  (displayln new-platlibdir))
+
+(define (handle-home-and-ver path-to-python)
+  (define data       (python-data))
+  (define prefix     (run-python-query path-to-python "import sys; print(sys.base_prefix)"))
+  (define pyver      (run-python-query path-to-python "import sys; print(f'{sys.version_info.major}.{sys.version_info.minor}')"))
+  (define platlibdir (run-python-query path-to-python "import sysconfig; print(sysconfig.get_config_var('platlibdir'))"))
+  (when (and prefix (not (equal? prefix "")))     (set-new-home prefix))
+  (when (and pyver  (not (equal? pyver "")))      (set-new-pyver pyver))
+  (when (and platlibdir (not (equal? platlibdir ""))) (set-new-platlibdir platlibdir))
+  (when (and data prefix (not (equal? data prefix)))
+    (set-new-venv data)))
+
 (define (configure [path-to-python #f])
   (get-configuration path-to-python)
   (handle-libdir path-to-python)
   (newline)
-  (handle-data   path-to-python))
+  (handle-data   path-to-python)
+  (newline)
+  (handle-home-and-ver path-to-python))
 
 (define (show)
   (displayln  "Current configuration for 'pyffi'.")

--- a/pyffi-lib/pyffi/python-initialization.rkt
+++ b/pyffi-lib/pyffi/python-initialization.rkt
@@ -19,7 +19,8 @@
 ; (define program-full-path "/Library/Frameworks/Python.framework/Versions/3.10/bin/python3.10")
 (define program-full-path "python3.10")
 
-(define home (get-preference 'pyffi:data (λ () #f)))
+(define home (or (get-preference 'pyffi:home (λ () #f))
+                 (get-preference 'pyffi:data (λ () #f))))
 (unless home
   (parameterize ([current-output-port (current-error-port)])
     (displayln "There is no preference for 'pyffi:data' set.")
@@ -125,9 +126,11 @@
 
   (define (decode s) (Py_DecodeLocale s #f))
 
-  (set-PyConfig-home!         config (decode home))
-  ; (set-PyConfig-program_name! config (decode "python3.10"))
-  (set-PyConfig-platlibdir! config   (decode (string-append home "/" "lib/python3.10")))
+  (define pyver      (get-preference 'pyffi:pyver      (λ () "3.12")))
+  (define platlibdir (get-preference 'pyffi:platlibdir (λ () "lib")))
+  (define venv       (get-preference 'pyffi:venv       (λ () #f)))
+  (set-PyConfig-home!       config (decode home))
+  (set-PyConfig-platlibdir! config (decode platlibdir))
   
   #;(let ([pythonpath (getenv "PYTHONPATH")])
     (when pythonpath
@@ -156,8 +159,19 @@
   #;(run-initialization-thunks))
 
 
-(define (post-initialize)  
-  (run-initialization-thunks))
+(define (post-initialize)
+  (run-initialization-thunks)
+  ; Inject venv site-packages into sys.path when a venv was configured.
+  (define venv-pref (get-preference 'pyffi:venv (λ () #f)))
+  (define pyver-pref (get-preference 'pyffi:pyver (λ () "3.12")))
+  (when venv-pref
+    (define sitepkg (string-append venv-pref "/lib/python" pyver-pref "/site-packages"))
+    (when (directory-exists? sitepkg)
+      (define import-site (PyImport_ImportModule "site"))
+      (define sys-mod     (PyImport_ImportModule "sys"))
+      (define sys-path    (PyObject_GetAttrString sys-mod "path"))
+      (PyList_Append sys-path (PyUnicode_FromString sitepkg))
+      (void))))
 
 (define (finish-initialization)
   (run-initialization-thunks))


### PR DESCRIPTION
Two closely-related issues that together stop `raco pyffi configure` from producing a workable setup when the target Python is in a venv:

1. PYTHONHOME should point at Python's base prefix (so the stdlib is found), not at the venv directory. sysconfig's `data` path is the venv when you point at a venv's bin/python3, so using it verbatim as home leaves Py_Initialize unable to find the `encodings` module and abort with ModuleNotFoundError.

2. `platlibdir` and the Python minor version are needed to locate the venv's `<venv>/lib/python<X.Y>/site-packages`, which has to be pushed onto `sys.path` after initialisation for venv-installed packages to be importable. Previously `platlibdir` was hardcoded to "lib/python3.10" which silently breaks on Python !=3.10.

configure-pyffi.rkt now shells out to the target Python to read `sys.base_prefix`, `sys.version_info`, and
`sysconfig.get_config_var('platlibdir')`, and stores the results under four new preferences: `pyffi:home`, `pyffi:pyver`, `pyffi:platlibdir`, and `pyffi:venv` (only set when the venv differs from the base prefix). `configure` runs the new phase last.

python-initialization.rkt reads PYTHONHOME from `pyffi:home` (falling back to `pyffi:data` for backwards compatibility), reads `platlibdir` from `pyffi:platlibdir`, and if `pyffi:venv` was set, appends `<venv>/lib/python<X.Y>/site-packages` to `sys.path` after `Py_InitializeFromConfig`.

No new dependencies. Existing installs that were configured before this change continue to work because `pyffi:home` falls back to `pyffi:data`.