### PR TITLE
Broaden find-libpython3 regex to match real Linux SONAMEs

### DIFF
--- a/pyffi-lib/pyffi/libpython.rkt
+++ b/pyffi-lib/pyffi/libpython.rkt
@@ -32,19 +32,42 @@
 
 
 ;; find-libpython3 : (or/c path-string? #f) -> (or/c path? #f)
-;;   If libpython-folder is a directory, return the path to a file named
-;;     libpython3.xx.<extension>
-;;   inside that directory, or #f if none is found or folder is #f.
+;;   If libpython-folder is a directory, return the path to a libpython
+;;   file inside it, or #f if none is found or folder is #f.
+;;
+;;   Filenames matched, by platform:
+;;     macOS  : libpython3.<X>[abi].dylib
+;;     Linux  : libpython3.<X>[abi].so[.<N>[.<M>...]]
+;;     Windows: libpython3.<X>[abi].dll           (rare — usually pythonXY.dll)
+;;
+;;   Where <X> is one or more digits (so Python 3.9 through 3.99+ all work)
+;;   and [abi] is an optional Python ABI flag letter such as `t`
+;;   (free-threaded, 3.13+), `d` (debug), or `m` (historical).
+;;
+;;   On Linux this accepts both the unversioned `.so` symlink and the
+;;   real SONAME variants like `libpython3.12.so.1.0`.  This matters on
+;;   distros that no longer ship the unversioned symlink in
+;;   libpython3-dev (Ubuntu 24.04 onward).
 (define (find-libpython3 libpython-folder)
   (cond
     [(not libpython-folder) #f]
     [else
      (define dir (path->complete-path libpython-folder))
      (define rx
-       ;; Example on macOS: ^libpython3\.[0-9][0-9]\.dylib$
-       (regexp (format "^libpython3\\.[0-9][0-9]~a$"
-                       (regexp-quote
-                        (string-append "." extension)))))
+       (case (system-type 'os)
+         [(unix)
+          ;; libpython3.12.so, libpython3.12.so.1, libpython3.12.so.1.0,
+          ;; libpython3.13t.so ...
+          #rx"^libpython3\\.[0-9]+[a-z]*\\.so(\\.[0-9]+)*$"]
+         [(macosx)
+          ;; libpython3.12.dylib, libpython3.13t.dylib
+          #rx"^libpython3\\.[0-9]+[a-z]*\\.dylib$"]
+         [(windows)
+          #rx"^libpython3\\.[0-9]+[a-z]*\\.dll$"]
+         [else
+          ;; Fallback: platform-specific extension with multi-digit minor.
+          (regexp (format "^libpython3\\.[0-9]+[a-z]*~a$"
+                          (regexp-quote (string-append "." extension))))]))
      (with-handlers ([exn:fail? (λ (_e) #f)])
        (for/or ([p (in-list (directory-list dir))])
          (let-values ([(base name must-dir?) (split-path p)])


### PR DESCRIPTION
The old regex ^libpython3\.[0-9][0-9]\.so$ only matched the unversioned libpython3.XX.so symlink, but that symlink no longer ships in libpython3-dev on Ubuntu 24.04 and newer.  The real files installed by the dev package are named

  libpython3.12.so.1.0
  libpython3.12.so.1
  libpython3.12.so

and only the last one (when present) matched.  On distros that drop it, find-libpython3 returned #f and pyffi fell back to dlopen-by-name which then required the caller to set PYFFI_LIBPYTHON or to create the symlink themselves.

The new regex accepts:
  - multi-digit Python minor (3.9..3.99..3.100+),
  - optional ABI flag letters (t for free-threaded 3.13+, d/m for debug/historical builds),
  - on Linux, the .so SONAME variants (libpython3.12.so.1.0 etc.).

Platform-specific:
  Linux:   ^libpython3\.[0-9]+[a-z]*\.so(\.[0-9]+)*$
  macOS:   ^libpython3\.[0-9]+[a-z]*\.dylib$
  Windows: ^libpython3\.[0-9]+[a-z]*\.dll$

This removes the need for consumers to manually symlink libpython3.so -> $INSTSONAME on modern distros.