### PR TITLE
Raise a typed exception instead of (exit 1) on missing configuration

### DIFF
--- a/pyffi-lib/pyffi/python-initialization.rkt
+++ b/pyffi-lib/pyffi/python-initialization.rkt
@@ -5,7 +5,8 @@
          "python-delayed.rkt"
          "python-constants.rkt"
          "structs.rkt"
-         racket/file)
+         racket/file
+         racket/string)
 
 (provide set-environment-variables
          initialize 
@@ -22,12 +23,14 @@
 (define home (or (get-preference 'pyffi:home (λ () #f))
                  (get-preference 'pyffi:data (λ () #f))))
 (unless home
-  (parameterize ([current-output-port (current-error-port)])
-    (displayln "There is no preference for 'pyffi:data' set.")
-    (displayln "You must set the 'pyffi:data' preference to the home folder of python.")
-    (displayln "The most convenient way to do this, is to run `raco pyffi configure`.")
-    (displayln "See details in the documentation.")
-    (exit 1)))
+  (raise (exn:fail:pyffi:not-configured
+          (string-join
+           '("pyffi is not configured: neither the 'pyffi:home nor 'pyffi:data preference is set."
+             "You must set 'pyffi:home (or, for backwards compatibility, 'pyffi:data) to the home"
+             "folder of Python.  The most convenient way to do this is to run"
+             "`raco pyffi configure`.  See details in the documentation.")
+           "\n")
+          (current-continuation-marks))))
 
 
 #;(define program-full-path
@@ -38,12 +41,14 @@
 
 (define libdir (get-preference 'pyffi:libdir (λ () #f)))
 (unless libdir
-  (parameterize ([current-output-port (current-error-port)])
-    (displayln "There is no preference for 'pyffi:libdir' set.")
-    (displayln "You must set the 'pyffi:libdir' preference to the home folder of python.")
-    (displayln "The most convenient way to do this, is to run `raco pyffi configure`.")
-    (displayln "See details in the documentation.")
-    (exit 1)))
+  (raise (exn:fail:pyffi:not-configured
+          (string-join
+           '("pyffi is not configured: the 'pyffi:libdir preference is not set."
+             "You must set 'pyffi:libdir to the folder containing libpython3."
+             "The most convenient way to do this is to run `raco pyffi configure`."
+             "See details in the documentation.")
+           "\n")
+          (current-continuation-marks))))
 
 (define (set-environment-variables)
   (define (decode s) (Py_DecodeLocale s #f))

--- a/pyffi-lib/pyffi/structs.rkt
+++ b/pyffi-lib/pyffi/structs.rkt
@@ -11,7 +11,26 @@
          (struct-out callable-obj)
          (struct-out method-obj)
          (struct-out generator-obj)
-         (struct-out asis))
+         (struct-out asis)
+
+         ;; Exceptions
+         (struct-out exn:fail:pyffi)
+         (struct-out exn:fail:pyffi:not-configured))
+
+;; ------------------------------------------------------------------
+;; Exception hierarchy
+;;
+;; `exn:fail:pyffi`                — anything pyffi itself raises
+;; `exn:fail:pyffi:not-configured` — pyffi's libpython / home preferences
+;;                                   are unset.  Raised (instead of
+;;                                   calling `(exit 1)`) so consumers
+;;                                   can catch the condition and present
+;;                                   a friendly message, fall back to a
+;;                                   stub implementation, etc.
+;; ------------------------------------------------------------------
+
+(struct exn:fail:pyffi exn:fail () #:transparent)
+(struct exn:fail:pyffi:not-configured exn:fail:pyffi () #:transparent)
 
 (struct pytype (type racket-to-python python-to-racket))
 


### PR DESCRIPTION
Previously python-initialization.rkt called `(exit 1)` at module top when either the `pyffi:home` / `pyffi:data` or `pyffi:libdir` preferences were unset.  This bypasses Racket's exception system:

  - consumers of pyffi cannot catch the failure and present a friendly message, fall back to a stub implementation, or continue with the parts of their program that do not need Python,

  - and any `raco setup` run that touches a module transitively requiring pyffi aborts with no hint that the user just needs to configure pyffi.

Downstream projects have been working around this by installing a custom `exit-handler` inside `parameterize` around their `dynamic-require` of pyffi — fragile and easy to get wrong.

This commit introduces a small exception hierarchy in structs.rkt:

    exn:fail:pyffi                  — anything pyffi itself raises
    exn:fail:pyffi:not-configured   — raised when libpython / home
                                      preferences are unset

and replaces both `(exit 1)` sites in python-initialization.rkt with `(raise (exn:fail:pyffi:not-configured ...))`.  The new struct types are re-exported through `pyffi/structs` and hence through `(require pyffi)`.

Callers can now do:

    (with-handlers ([exn:fail:pyffi:not-configured?
                     (λ (e) ... display a helpful message ...)])
      (dynamic-require 'pyffi 0))

and module-top raises during pyffi initialization propagate through `dynamic-require` as ordinary exceptions (verified).

Behaviour when pyffi IS configured is unchanged.