### PR TITLE
Make pyffi-lib compile when libpython is not present

### DIFF
--- a/pyffi-lib/pyffi/libpython.rkt
+++ b/pyffi-lib/pyffi/libpython.rkt
@@ -152,15 +152,32 @@
                  "library name (e.g. libpython3.12).")))]))
 
 ;; Note: We use #:global? #t so that symbols are visible to extension modules.
-;; IMPORTANT: Delay loading so that compilation/docs don't require libpython.
+;;
+;; Errors during path resolution or `ffi-lib` are caught and turned into
+;; a #f library handle.  Two reasons:
+;;
+;;   1. `define-ffi-definer` below caches its lib expression at module
+;;      init time, which forces this promise during compilation.  The
+;;      Racket package-build server (and any other system that compiles
+;;      pyffi without Python installed) needs that step to succeed even
+;;      when libpython is absent.  With a #f lib handle, the bindings
+;;      defined by `define-python` become "not available" stubs (via
+;;      `#:default-make-fail make-not-available`); the module compiles,
+;;      and any actual call into Python fails at the call site rather
+;;      than at compile time.
+;;
+;;   2. Downstream consumers that want to require pyffi optionally
+;;      (e.g. only when Python is configured) can load the package and
+;;      then check `(get-lib)` themselves before calling anything.
 (define lib*
-  (delay (ffi-lib (resolve-libpython-path) #:global? #t)))
+  (delay
+    (with-handlers ([exn:fail? (λ (_) #f)])
+      (ffi-lib (resolve-libpython-path) #:global? #t))))
 
 (define (get-lib)
   (force lib*))
 
 (require pyffi/parameters)
 
-;; define-python is a macro, but the library expression is evaluated at runtime.
 (define-ffi-definer define-python (get-lib)
   #:default-make-fail make-not-available)

--- a/pyffi-lib/pyffi/python-c-api.rkt
+++ b/pyffi-lib/pyffi/python-c-api.rkt
@@ -20,6 +20,18 @@
 (require racket/format racket/match racket/string
          (for-syntax racket/base  racket/format
                      syntax/parse racket/syntax))
+
+;; A handful of Python singletons (Py_False, Py_True, the-None) are
+;; computed at module init by calling into libpython.  When libpython
+;; isn't loadable (e.g. when the package-build server compiles pyffi
+;; without Python installed), `define-python` produces "not available"
+;; stubs that error if called.  Wrapping each top-level FFI initialiser
+;; in `lazy-ffi` lets module init succeed in that case — the singleton
+;; binds to #f, and any actual use will already have failed earlier at
+;; `(initialize)`/Py_Initialize_FromConfig time.  See libpython.rkt for
+;; the matching tolerance in the lib-load path.
+(define-syntax-rule (lazy-ffi expr)
+  (with-handlers ([exn:fail? (λ (_) #f)]) expr))
 ;;;
 ;;; TYPES
 ;;;
@@ -206,13 +218,13 @@
 (define-python PyBool_FromLong (_fun _long -> [o : _PyObject*] -> (new-reference o)))
 ; Return a new reference to Py_True or Py_False depending on the truth value of v.
 
-(define Py_False (PyBool_FromLong 0))
+(define Py_False (lazy-ffi (PyBool_FromLong 0)))
 ;   The Python False object. This object has no methods.
 ;   It needs to be treated just like any other object with respect to reference counts.
 ;   When used as a return value, remember to increment the reference count.
 ;   [Use Py_RETURN_FALSE]
 
-(define Py_True (PyBool_FromLong 1))
+(define Py_True (lazy-ffi (PyBool_FromLong 1)))
 ; The Python True object. This object has no methods.
 ; It needs to be treated just like any other object with respect to reference counts.
 ;   When used as a return value, remember to increment the reference count.
@@ -402,7 +414,7 @@
 (define-python Py_BuildValue0 (_fun #:varargs-after 1 _string -> [o : _PyObject*] -> (new-reference o))
   #:c-id Py_BuildValue)
 
-(define the-None (Py_BuildValue0 ""))
+(define the-None (lazy-ffi (Py_BuildValue0 "")))
 (define (build-None)
   (Py_IncRef the-None)
   the-None)


### PR DESCRIPTION
The Racket package-build service compiles every package on a fresh machine that does not have libpython installed.  pyffi-lib's `raco setup` step has been failing with

    ffi-lib: could not load foreign library
      path: libpython3.so
      system error: libpython3.so: cannot open shared object file
    body of "/<pkgs>/pyffi-lib/pyffi/libpython.rkt"

because two pieces of pyffi exercise libpython at module-init time:

1. `define-ffi-definer` in libpython.rkt evaluates its lib expression once at module init.  The existing `(delay (ffi-lib ...))` is forced by that evaluation, so `ffi-lib` runs during compilation.  When the library isn't present, the error aborts the build.

2. python-c-api.rkt has three top-level FFI initialisers (`Py_False`, `Py_True`, `the-None`) that call into libpython at module init.  When `define-python` produced "not available" stubs (because lib was missing), those calls error.

This commit:

  - In libpython.rkt, wraps the `ffi-lib` call in a `with-handlers` so it returns `#f` instead of raising on failure.  `define-ffi-definer` with `#:default-make-fail make-not-available` already turns a `#f` lib into "not available" stubs that error only at use, so module init succeeds.

  - In python-c-api.rkt, adds a tiny `lazy-ffi` macro (`with-handlers exn:fail? -> #f`) and uses it for the three module-top FFI initialisers.  Their values become `#f` when libpython isn't loadable; any actual use of pyffi already fails earlier at `(initialize)` time.

Verified locally:

  - With `PYFFI_LIBPYTHON=/nonexistent.so` and no preferences, `raco make pyffi-lib/pyffi/main.rkt` compiles all 28 .zo files cleanly (previously failed at libpython.rkt then python-c-api.rkt).

  - On a properly configured host pyffi rebuilds normally and a downstream consumer produces the expected output. Really I would like a bigger test set but that is all i have at the moment.
 
 Give it a whirl it's not like we will stop the package being built.