### PR TITLE
Natipkg discovery

### DIFF
--- a/NATIPKG.md
+++ b/NATIPKG.md
@@ -1,0 +1,177 @@
+# pyffi natipkg integration
+
+This document explains the platform-specific natipkg companions
+that `pyffi-lib` declares as build-dependencies, and how they fit
+into the catalogue / build / install flow. It is reference
+material for maintainers; end users do not need to read this.
+
+## What problem this solves
+
+The Racket package-build server at `pkg-build.racket-lang.org`
+runs on a Linux VM that has no Python development files
+installed. Building `pyffi-doc` requires evaluating Scribble
+example blocks that import real Python through pyffi's FFI.
+Without a `libpython.so` reachable on disk, those evaluations
+abort and the catalogue never produces a successful pyffi build
+artefact — which has been pyffi's state on the catalogue since
+2022 (1254 days as of 2026-04-25, with `success-log = #f` on every
+package metadata snapshot).
+
+The fix is the standard convention used by `math-lib`,
+`draw-lib`, `gui-lib`, etc.: ship the platform-specific binary
+through a sibling natipkg package, declared as a
+platform-conditional build-dep.
+
+## The four natipkg companions
+
+| Catalogue package                | Platform regex                  | Source                                 |
+| :------------------------------- | :------------------------------ | :------------------------------------- |
+| `pyffi-aarch64-linux-natipkg`    | `aarch64-linux`                 | python-build-standalone install_only_stripped |
+| `pyffi-x86_64-linux-natipkg`     | `x86_64-linux-natipkg`          | python-build-standalone install_only_stripped |
+| `pyffi-aarch64-macosx-natipkg`   | `aarch64-macosx`                | python-build-standalone install_only          |
+| `pyffi-x86_64-macosx-natipkg`    | `x86_64-macosx`                 | python-build-standalone install_only          |
+
+The build server identifies as `x86_64-linux-natipkg`
+specifically (distinct from plain `x86_64-linux`), so the second
+entry is the one that fires there. The other three exist so a
+maintainer running `raco setup` on another host (e.g. building
+docs locally before publishing) gets the same tooling without
+having to install Python.
+
+All four bundle CPython 3.12 from
+[`astral-sh/python-build-standalone`](https://github.com/astral-sh/python-build-standalone).
+Their source repository is
+[`lamestllama/pyffi-natipkg-bundle`](https://github.com/lamestllama/pyffi-natipkg-bundle)
+— one git tree with four subdirs, one catalogue package per
+subdir.
+
+## info.rkt
+
+In `pyffi-lib/info.rkt`:
+
+```racket
+(define deps '("base" "at-exp-lib"))   ; runtime — unchanged
+
+(define build-deps
+  '("base" "at-exp-lib"
+    ("pyffi-aarch64-linux-natipkg"  #:platform "aarch64-linux")
+    ("pyffi-x86_64-linux-natipkg"   #:platform "x86_64-linux-natipkg")
+    ("pyffi-aarch64-macosx-natipkg" #:platform "aarch64-macosx")
+    ("pyffi-x86_64-macosx-natipkg"  #:platform "x86_64-macosx")))
+```
+
+Notice `build-deps`, not `deps`. End users running
+`raco pkg install pyffi` against the source catalogue or pulling
+the prebuilt snapshot do not download a natipkg — only build
+hosts (running `raco setup` for compilation/doc-rendering) do.
+That keeps a normal install ~50 MB lighter than it would
+otherwise be.
+
+## Discovery logic
+
+`pyffi-lib/pyffi/libpython.rkt` resolves the libpython path in
+this order, returning the first hit:
+
+1. `PYFFI_LIBPYTHON` environment variable
+2. `pyffi:libdir` / `pyffi:home` preferences (set by
+   `raco pyffi configure`)
+3. The matching natipkg companion (located via `pkg-directory`
+   from `pkg/lib`; returns `#f` cleanly if the package is not
+   installed)
+4. Dynamic loader search by candidate name (`libpython3.12`,
+   `libpython3`, etc.)
+5. Error
+
+`pyffi-lib/pyffi/python-initialization.rkt` parallels this for
+PYTHONHOME — it falls through to the natipkg's package root
+(canonicalised via `simple-form-path`) if no `pyffi:home` /
+`pyffi:data` preference is set.
+
+The user-facing precedence is unchanged from before: explicit
+configuration always wins over auto-discovery. The natipkg path
+is purely a fallback, only fires in build environments where it's
+been installed via build-deps.
+
+## Catalogue registration
+
+For pkg-build to actually use the natipkgs, the four packages
+need entries on `pkgs.racket-lang.org`. Each entry's source URL
+is the bundle repo with a `?path=` query string:
+
+```
+pyffi-aarch64-linux-natipkg
+  → https://github.com/lamestllama/pyffi-natipkg-bundle.git?path=pyffi-aarch64-linux-natipkg#main
+
+pyffi-x86_64-linux-natipkg
+  → https://github.com/lamestllama/pyffi-natipkg-bundle.git?path=pyffi-x86_64-linux-natipkg#main
+
+pyffi-aarch64-macosx-natipkg
+  → https://github.com/lamestllama/pyffi-natipkg-bundle.git?path=pyffi-aarch64-macosx-natipkg#main
+
+pyffi-x86_64-macosx-natipkg
+  → https://github.com/lamestllama/pyffi-natipkg-bundle.git?path=pyffi-x86_64-macosx-natipkg#main
+```
+
+Each is its own catalogue entry, separately versioned by
+checksum. Once registered, the next pkg-build run picks them up
+through pyffi-lib's `build-deps` and finally produces a successful
+pyffi build.
+
+The bundle repo can stay under `lamestllama` or be transferred to
+`soegaard` at the maintainer's discretion — the catalogue source
+URLs change in either case but nothing in pyffi-lib needs to
+move.
+
+## Updating the bundled Python
+
+When a new python-build-standalone release is worth picking up:
+
+1. Choose the new release date (e.g. `20260615`) and Python
+   patch version (e.g. `3.12.14`).
+2. In `pyffi-natipkg-bundle`, replace each subdir's `lib/`
+   contents from the matching install_only(_stripped) tarball.
+   Keep the Linux symlinks
+   (`libpython3.12.so → libpython3.12.so.1.0`, `libpython3.so`).
+3. Update each `info.rkt`'s `pkg-desc` if the Python version
+   string in it changed.
+4. Commit all four updates together (single commit, `git push`).
+5. The catalogue's daily refresh picks up the new checksum;
+   pkg-build will rebuild pyffi-lib + pyffi-doc against the new
+   bundled Python.
+
+A version bump is one PR to one repo, four file replacements.
+
+## End-user perspectives
+
+| Scenario                                                                | Files downloaded                                          | Need libpython at install? | Need libpython at runtime?       |
+| :---------------------------------------------------------------------- | :-------------------------------------------------------- | :------------------------- | :------------------------------- |
+| `raco pkg install pyffi` against snapshot catalogue (prebuilt)          | pyffi-lib + pyffi-doc only (with prebuilt .zo + HTML)     | No (artefacts prebuilt)    | Yes, via configured Python       |
+| `raco pkg install pyffi` against source catalogue                       | pyffi-lib + pyffi-doc + matching natipkg (build-dep)      | Yes (uses natipkg)         | Yes, via configured Python       |
+| `raco pkg install pyffi --no-setup`                                     | pyffi-lib only (no doc-build, no natipkg)                 | No                         | Yes, via configured Python       |
+| `raco pkg install pyffi-<arch>-<os>-natipkg` directly                   | one natipkg                                               | n/a                        | Bundled Python via natipkg path  |
+
+All paths converge on the user having a usable Python at
+runtime; the natipkg only ever supplies `libpython` to the
+build stage.
+
+## Files in this PR
+
+- `pyffi-lib/info.rkt` — adds the four `build-deps` entries.
+- `pyffi-lib/pyffi/libpython.rkt` — adds natipkg discovery
+  (`current-natipkg-name`, `natipkg-lib-dir`, `pyffi-natipkg-root`)
+  in the resolver between user preferences and the loader search.
+- `pyffi-lib/pyffi/python-initialization.rkt` — falls through to
+  the natipkg root for PYTHONHOME; canonicalises via
+  `simple-form-path`; uses `(or (get-preference …) "default")`
+  for `pyver` / `platlibdir` reads so a preference deliberately
+  cleared to `#f` doesn't crash Python at module init.
+- `NATIPKG.md` — this document.
+
+## What this PR does not change
+
+- The user-facing API of pyffi.
+- The `raco pyffi configure` / `raco pyffi show` flow.
+- The behaviour for users with a configured system Python (their
+  configuration still wins in step 2 of the discovery order; the
+  natipkg path never overrides it).
+- Existing CI workflows or test runs.

--- a/pyffi-lib/info.rkt
+++ b/pyffi-lib/info.rkt
@@ -2,19 +2,32 @@
 
 (define collection 'multi)
 
-(define deps '("base" "at-exp-lib"
-               ;; If we want to distribute Python as a package, we will need:
-               ;; ("python-i386-macosx"          #:platform "i386-macosx")
-               ;; ("python-x86_64-macosx"        #:platform "x86_64-macosx")
-               ;; ("python-ppc-macosx"           #:platform "ppc-macosx")
-               ;; ("python-aarch64-macosx"       #:platform "aarch64-macosx")
-               ;; ("python-win32-i386"           #:platform "win32\\i386")
-               ;; ("python-win32-x86_64"         #:platform "win32\\x86_64")
-               ;; ("python-win32-arm64"          #:platform "win32\\arm64")
-               ;; ("python-x86_64-linux-natipkg" #:platform "x86_64-linux-natipkg")
-               ))
+(define deps '("base" "at-exp-lib"))
 
-(define build-deps (list "base" "at-exp-lib"))
+;; Platform-specific natipkg companions: each one bundles a
+;; relocatable CPython 3.12 (libpython + stdlib) for one target.
+;; They are *build-only* dependencies, not runtime dependencies.
+;;
+;; End users configure their own Python with `raco pyffi configure`
+;; (or set the env var / preferences directly), so a normal install
+;; does not download a natipkg.  The natipkg only exists to give
+;; the package-build server a real libpython to link pyffi-doc's
+;; Scribble examples against — without it the catalogue build of
+;; pyffi-doc fails because the live examples can't import any
+;; Python module.
+;;
+;; The build-server platform string is "x86_64-linux-natipkg"
+;; specifically (distinct from "x86_64-linux"), so the second
+;; entry below is the one that actually fires on pkg-build.  The
+;; other three are there so a maintainer running `raco setup` on
+;; another host (e.g. building docs locally before publishing) can
+;; pick up the same fallback.
+(define build-deps
+  '("base" "at-exp-lib"
+    ("pyffi-aarch64-linux-natipkg"  #:platform "aarch64-linux")
+    ("pyffi-x86_64-linux-natipkg"   #:platform "x86_64-linux-natipkg")
+    ("pyffi-aarch64-macosx-natipkg" #:platform "aarch64-macosx")
+    ("pyffi-x86_64-macosx-natipkg"  #:platform "x86_64-macosx")))
 
 
 (define pkg-desc "Use Python from Racket - Implementation part without documentation")

--- a/pyffi-lib/pyffi/libpython.rkt
+++ b/pyffi-lib/pyffi/libpython.rkt
@@ -1,14 +1,16 @@
 #lang at-exp racket/base
 
 ;;;  This module loads the shared library `libpython` and
-;;;  provides the form `define-python` which is used to 
+;;;  provides the form `define-python` which is used to
 ;;;  create bindings for Python's C-API.
 
-(provide define-python)
+(provide define-python
+         pyffi-natipkg-root)
 
 ;;; Imports
 
-(require ffi/unsafe ffi/unsafe/define racket/file racket/list racket/promise)
+(require ffi/unsafe ffi/unsafe/define racket/file racket/list racket/promise
+         pkg/lib)
 
 
 ;;; Configuration
@@ -132,24 +134,92 @@
     "libpython3.14" "libpython3.13" "libpython3.12" "libpython3.11" "libpython3.10"
     "libpython310"))
 
+;; ---------------------------------------------------------------------------
+;; natipkg auto-discovery
+;;
+;; When the user has neither `pyffi:libdir` nor `PYFFI_LIBPYTHON` set, look
+;; for a sibling platform-specific natipkg package (`pyffi-<arch>-<os>-natipkg`)
+;; that bundles a relocatable libpython plus its stdlib.  The natipkg
+;; packages are installed automatically on matching platforms via pyffi-lib's
+;; `platform-deps` declaration.  Each `define-runtime-path` below resolves at
+;; module init against the installed package layout; if a natipkg isn't
+;; installed, the resolved path points at a non-existent directory and is
+;; filtered out by `directory-exists?`.
+;; ---------------------------------------------------------------------------
+
+(define (current-natipkg-name)
+  (case (system-type 'os)
+    [(unix)
+     (case (system-type 'arch)
+       [(aarch64) "pyffi-aarch64-linux-natipkg"]
+       [(x86_64)  "pyffi-x86_64-linux-natipkg"]
+       [else #f])]
+    [(macosx)
+     (case (system-type 'arch)
+       [(aarch64) "pyffi-aarch64-macosx-natipkg"]
+       [(x86_64)  "pyffi-x86_64-macosx-natipkg"]
+       [else #f])]
+    [else #f]))
+
+(define (natipkg-lib-dir)
+  ;; Locate the lib/ directory of the natipkg matching the current
+  ;; host, or #f if the natipkg isn't installed or the platform isn't
+  ;; covered.  `pkg-directory` returns #f cleanly for absent packages
+  ;; (in contrast to `define-runtime-path` with a `'(lib …)` form,
+  ;; which fails hard at compile time when the collection is missing).
+  (define name (current-natipkg-name))
+  (and name
+       (with-handlers ([exn:fail? (λ (_) #f)])
+         (define dir (pkg-directory name))
+         (and dir
+              (let ([lib (build-path dir "lib")])
+                (and (directory-exists? lib) lib))))))
+
+(define (natipkg-libpython)
+  (define dir (natipkg-lib-dir))
+  (and dir (find-libpython3 dir)))
+
+;; Public: the natipkg's package root (the parent of its lib dir), or #f if
+;; no natipkg is present.  python-initialization.rkt reads this to default
+;; PYTHONHOME so Py_Initialize finds the bundled stdlib.
+(define (pyffi-natipkg-root)
+  (define lib (natipkg-lib-dir))
+  (and lib
+       (let-values ([(parent _ _2) (split-path lib)])
+         (and (path? parent) parent))))
+
+;; ---------------------------------------------------------------------------
+;; Discovery order
+;;
+;;   1. PYFFI_LIBPYTHON      — explicit env-var override (highest priority)
+;;   2. pyffi:libdir         — explicit user config (raco pyffi configure)
+;;   3. natipkg auto-discovery — bundled libpython if a natipkg is installed
+;;   4. dynamic loader search by name — last-resort default
+;;   5. error                — nothing found
+;; ---------------------------------------------------------------------------
+
 (define (resolve-libpython-path)
   (cond
     [(env-libpython)
      (env-libpython)]
     [else
-     (or (find-libpython3 libpython-folder) ; full path inside libpython-folder
-         (for/first ([name (in-list (candidates))]
+     (or (find-libpython3 libpython-folder)         ; user pref (pyffi:libdir)
+         (for/first ([name (in-list (candidates))]  ; user pref by candidate name
                      #:when (file-exists? (build-full-path name)))
            (path->string (build-full-path name)))
-         ;; If libpython-folder is not set, allow dynamic loader search by name:
-         (for/first ([name (in-list (candidates))])
+         (let ([p (natipkg-libpython)])             ; bundled natipkg
+           (and p (path->string p)))
+         (for/first ([name (in-list (candidates))]) ; loader search by name
            name)
          (error 'pyffi
                 (string-append
                  "Could not find/load libpython.\n"
-                 "Set preference 'pyffi:libdir' (raco pyffi configure), or set\n"
-                 "environment variable PYFFI_LIBPYTHON to a full path or a\n"
-                 "library name (e.g. libpython3.12).")))]))
+                 "Try one of:\n"
+                 " - Install the natipkg companion (e.g.\n"
+                 "   `raco pkg install pyffi-aarch64-linux-natipkg`).\n"
+                 " - Set preference 'pyffi:libdir' (raco pyffi configure).\n"
+                 " - Set environment variable PYFFI_LIBPYTHON to a full path\n"
+                 "   or a library name (e.g. libpython3.12).")))]))
 
 ;; Note: We use #:global? #t so that symbols are visible to extension modules.
 ;; IMPORTANT: Delay loading so that compilation/docs don't require libpython.

--- a/pyffi-lib/pyffi/python-initialization.rkt
+++ b/pyffi-lib/pyffi/python-initialization.rkt
@@ -6,6 +6,7 @@
          "python-constants.rkt"
          "structs.rkt"
          racket/file
+         racket/path
          racket/string)
 
 (provide set-environment-variables
@@ -30,7 +31,10 @@
   (or (get-preference 'pyffi:home (λ () #f))
       (get-preference 'pyffi:data (λ () #f))
       (let ([root (pyffi-natipkg-root)])
-        (and root (path->string (path->complete-path root))))))
+        ;; `simple-form-path` collapses any `..` segments introduced
+        ;; by `pkg-directory`'s symlinked-install layout, so
+        ;; Py_Initialize gets a canonical PYTHONHOME.
+        (and root (path->string (simple-form-path root))))))
 (unless home
   (raise (exn:fail:pyffi:not-configured
           (string-join
@@ -128,9 +132,13 @@
 
   (define (decode s) (Py_DecodeLocale s #f))
 
-  (define pyver      (get-preference 'pyffi:pyver      (λ () "3.12")))
-  (define platlibdir (get-preference 'pyffi:platlibdir (λ () "lib")))
-  (define venv       (get-preference 'pyffi:venv       (λ () #f)))
+  ;; Read preferences with defaults.  Each `or` guards against a
+  ;; preference that was deliberately cleared to #f — `get-preference`
+  ;; returns #f in that case instead of the default thunk's value,
+  ;; and passing #f to `Py_DecodeLocale` crashes Python.
+  (define pyver      (or (get-preference 'pyffi:pyver      (λ () #f)) "3.12"))
+  (define platlibdir (or (get-preference 'pyffi:platlibdir (λ () #f)) "lib"))
+  (define venv       (get-preference 'pyffi:venv (λ () #f)))
   (set-PyConfig-home!       config (decode home))
   (set-PyConfig-platlibdir! config (decode platlibdir))
   

--- a/pyffi-lib/pyffi/python-initialization.rkt
+++ b/pyffi-lib/pyffi/python-initialization.rkt
@@ -20,35 +20,32 @@
 ; (define program-full-path "/Library/Frameworks/Python.framework/Versions/3.10/bin/python3.10")
 (define program-full-path "python3.10")
 
-(define home (or (get-preference 'pyffi:home (λ () #f))
-                 (get-preference 'pyffi:data (λ () #f))))
+;; PYTHONHOME resolution order:
+;;   1. 'pyffi:home preference (explicit user config via raco pyffi configure)
+;;   2. 'pyffi:data preference (legacy fallback for old configurations)
+;;   3. The natipkg companion's package root, if a natipkg is installed
+;;      and bundles a relocatable Python (libpython + stdlib).
+;;   4. Error — pyffi is not configured.
+(define home
+  (or (get-preference 'pyffi:home (λ () #f))
+      (get-preference 'pyffi:data (λ () #f))
+      (let ([root (pyffi-natipkg-root)])
+        (and root (path->string (path->complete-path root))))))
 (unless home
   (raise (exn:fail:pyffi:not-configured
           (string-join
-           '("pyffi is not configured: neither the 'pyffi:home nor 'pyffi:data preference is set."
-             "You must set 'pyffi:home (or, for backwards compatibility, 'pyffi:data) to the home"
-             "folder of Python.  The most convenient way to do this is to run"
-             "`raco pyffi configure`.  See details in the documentation.")
+           '("pyffi is not configured: neither 'pyffi:home nor 'pyffi:data is set,"
+             "and no natipkg companion (e.g. pyffi-aarch64-linux-natipkg) is installed."
+             "Either install a natipkg companion to use a bundled Python, or run"
+             "`raco pyffi configure /path/to/python3` to point at a system install.")
            "\n")
           (current-continuation-marks))))
 
 
-#;(define program-full-path
-   "/usr/local/Cellar/python@3.10/3.10.4/Frameworks/Python.framework/Versions/3.10/bin/python3.10")
-
-; (define home "/usr/local/Cellar/python@3.10/3.10.4/Frameworks/Python.framework/Versions/3.10")
-
-
-(define libdir (get-preference 'pyffi:libdir (λ () #f)))
-(unless libdir
-  (raise (exn:fail:pyffi:not-configured
-          (string-join
-           '("pyffi is not configured: the 'pyffi:libdir preference is not set."
-             "You must set 'pyffi:libdir to the folder containing libpython3."
-             "The most convenient way to do this is to run `raco pyffi configure`."
-             "See details in the documentation.")
-           "\n")
-          (current-continuation-marks))))
+;; The actual libpython load is handled by libpython.rkt, which knows
+;; how to discover the library across env vars, user prefs, the
+;; natipkg companion and the dynamic loader.  python-initialization
+;; only needs PYTHONHOME (the `home` value above) for Py_Initialize.
 
 (define (set-environment-variables)
   (define (decode s) (Py_DecodeLocale s #f))


### PR DESCRIPTION
This is the Mechanism 2 follow-on to #9 — give the package-build
server a real libpython so it can render pyffi-doc's live Scribble
examples, without making end users download anything extra.

The PR is code-only.  The four binary natipkg companion packages
live in a separate dedicated repo at
https://github.com/lamestllama/pyffi-natipkg-bundle. I have invited you as admin so you can take ownership

## What this PR ships

- `pyffi-lib/info.rkt`: four platform-conditional **build-deps**
  entries (note: build-deps, not runtime deps — see "End-user
  flows" below).
- `pyffi-lib/pyffi/libpython.rkt`: discovery for an installed
  natipkg companion in `resolve-libpython-path`, between user
  preferences and the dynamic-loader fallback.  Looked up via
  `pkg-directory` from `pkg/lib`, which returns #f cleanly when
  the package isn't installed.
- `pyffi-lib/pyffi/python-initialization.rkt`: PYTHONHOME falls
  through to the natipkg's package root (canonicalised via
  `simple-form-path`).  Plus two corner-case fixes that surfaced
  while testing the natipkg path:
    - `pyver` and `platlibdir` reads use `(or (get-preference …) "default")`
      so a preference deliberately cleared to #f doesn't reach
      Py_DecodeLocale and crash module init.
    - `simple-form-path` collapses the `..` segments that
      `pkg-directory` returns from the symlinked-install layout —
      Py_Initialize rejects non-canonical PYTHONHOMEs.
- `NATIPKG.md`: full integration design doc (catalog registration
  steps, discovery logic, end-user flow matrix, update procedure).

## Discovery order (existing user-facing precedence preserved)

  1. PYFFI_LIBPYTHON env var
  2. pyffi:libdir / pyffi:home preferences (raco pyffi configure)
  3. Bundled natipkg companion (only present in build envs / opt-in)
  4. Dynamic loader search by candidate name
  5. Error

Explicit user configuration always wins over auto-discovery.  The
natipkg path only fires for environments that have no system Python
and no manual configuration — primarily the package-build server.

## End-user flows

| Scenario                                                | Natipkg downloaded?            | Need libpython at install? |
| :------------------------------------------------------ | :----------------------------- | :------------------------- |
| `raco pkg install pyffi` from snapshot catalog          | No (build-deps not installed)  | No (artefacts prebuilt)    |
| `raco pkg install pyffi` from source catalog            | Yes (matching one only)        | Yes (uses natipkg)         |
| `raco pkg install pyffi --no-setup`                     | No                             | No                         |
| Direct: `raco pkg install pyffi-<arch>-<os>-natipkg`    | One                            | n/a (uses bundled Python)  |

End users pulling prebuilt snapshots get a working `raco pkg install
pyffi` with no natipkg download — the build server paid for the
bundled Python once and shipped the result.

## Bundle repo

`lamestllama/pyffi-natipkg-bundle` ships, as four sibling subdirs,
relocatable CPython 3.12.13 from python-build-standalone release
20260414:

  pyffi-aarch64-linux-natipkg     ~46 MB  (install_only_stripped)
  pyffi-x86_64-linux-natipkg      ~55 MB  (install_only_stripped)
  pyffi-aarch64-macosx-natipkg    ~40 MB  (install_only)
  pyffi-x86_64-macosx-natipkg     ~40 MB  (install_only)

Each subdir is a separate Racket catalog package; raco fetches only
the entry matching the host platform.  Linux uses the stripped
variant to keep individual files under GitHub's 100 MB hard limit.

## What you (Jens) need to do to land this

### 1. Accept the two collaborator invitations

I've added you as admin on both repos so you can take over either
side wherever it's easier than working through the PR:

- https://github.com/lamestllama/pyffi/invitations
- https://github.com/lamestllama/pyffi-natipkg-bundle/invitations

### 2. (Optional) Transfer the bundle repo to your namespace

If you'd prefer `soegaard/pyffi-natipkg-bundle`, the transfer is one
click in repo settings once you've accepted the admin invite.  The
catalog source URLs in step 4 below would change accordingly; nothing
in this PR needs to move.

### 3. Review and merge this PR

Code diff is small.  The single decision worth checking is
`build-deps`-not-`deps` in `pyffi-lib/info.rkt` — that's what makes
end users not pay the natipkg download.

### 4. Register the four natipkg packages on the catalog

Only you can do this.  For each, register at
https://pkgd.racket-lang.org/pkgn/manage with these source URLs:

  pyffi-aarch64-linux-natipkg
    https://github.com/lamestllama/pyffi-natipkg-bundle.git?path=pyffi-aarch64-linux-natipkg#main

  pyffi-x86_64-linux-natipkg
    https://github.com/lamestllama/pyffi-natipkg-bundle.git?path=pyffi-x86_64-linux-natipkg#main

  pyffi-aarch64-macosx-natipkg
    https://github.com/lamestllama/pyffi-natipkg-bundle.git?path=pyffi-aarch64-macosx-natipkg#main

  pyffi-x86_64-macosx-natipkg
    https://github.com/lamestllama/pyffi-natipkg-bundle.git?path=pyffi-x86_64-macosx-natipkg#main

Author / ring / tags can match the existing `pyffi` package.

### 5. Wait for the next pkg-build cycle

Once the catalog has the four natipkgs registered AND main has the
merged PR, the next pkg-build run picks up `pyffi-x86_64-linux-natipkg`
via the platform-conditional `build-deps`, has a real libpython on
disk, successfully renders pyffi-doc's Scribble examples, and
produces the snapshot.  End users pulling from the snapshot catalog
get a working `raco pkg install pyffi` for the first time.

### 6. Sanity-check the build

Once pkg-build has run, the catalog pages for `pyffi`, `pyffi-lib`,
and `pyffi-doc` should drop the `:build-fail:` tag and grow a
`success-log` value.  The four natipkg pages will be green from the
start.  If anything is still red, the transcript at
`https://pkg-build.racket-lang.org/server/built/fail/<pkg>.txt`
shows the specific step — happy to chase any of that down with you.

## Maintenance after this lands

Bumping the bundled Python (e.g. 3.12.13 → 3.12.14) is one PR to one
repo:

  1. Download the four matching `cpython-<X.Y.Z>+<DATE>-<arch>-…-install_only*.tar.gz`
     tarballs.
  2. In `pyffi-natipkg-bundle`, replace each subdir's `lib/` contents
     (keep the Linux symlinks).
  3. Single commit, single push.

Catalog refresh picks up the new checksums automatically; pkg-build
rebuilds pyffi against the new bundled Python.  NATIPKG.md in this
PR documents the procedure with copy-paste shell commands.

## Test plan

- [x] Existing `raco pyffi configure` setup: configured Python wins;
      downstream consumers (glang's core-export plugin) work
      end-to-end unchanged.
- [x] Prefs cleared + matching natipkg locally linked: pyffi finds
      it, initialises Python 3.12.13, evaluates expressions.  This
      is exactly the build-server scenario.
- [x] `raco setup --only pyffi` rebuilds cleanly on the branch.

## What's not in this PR

- Python 3.10 / 3.11 / 3.13 variants — easy follow-up via
  versioned natipkg names plus a small extension to the discovery
  to read `pyffi:pyver`.  Out of scope here.
- Windows variants — python-build-standalone publishes the builds
  but pyffi's Windows runtime path isn't tested.
- Auto-detecting a system Python at install time so users don't have
  to run `raco pyffi configure` — discussed and deferred.  Users
  having a configured Python is the assumed precondition.

Regards Eric