### PR TITLE
configure-pyffi: omit from raco test via test-omit-paths

### DIFF
--- a/pyffi-lib/pyffi/configure-pyffi.rkt
+++ b/pyffi-lib/pyffi/configure-pyffi.rkt
@@ -365,5 +365,5 @@
      [(list "diagnostics")              (diagnostics)]
      [else                              (display-usage)
                                         (exit 3)])))
-  
+
 (run)

--- a/pyffi-lib/pyffi/info.rkt
+++ b/pyffi-lib/pyffi/info.rkt
@@ -5,3 +5,13 @@
 
 (define raco-commands
   (list (list "pyffi" 'pyffi/configure-pyffi "configure pyffi" #f)))
+
+;; configure-pyffi.rkt is a `raco pyffi` command-line script: it
+;; dispatches via `command-line` at the top level so `raco pyffi
+;; <subcommand>` works.  Without this exclusion, `raco test` (which
+;; the pkg-build server runs over every .rkt in the package) would
+;; load it as a script with no extra argv, fall through to the
+;; usage-fallback `(exit 3)` branch, and report a spurious test
+;; failure.
+(define test-omit-paths
+  '("configure-pyffi.rkt"))


### PR DESCRIPTION
## Summary

`pkg-build.racket-lang.org` reports `pyffi-lib` as failing tests with `non-zero exit: 3` on `pyffi/configure-pyffi.rkt` (https://pkg-build.racket-lang.org/server/built/test-fail/pyffi-lib.txt).

`raco test` loads every `.rkt` under the package and runs each as a script with no extra argv.  `configure-pyffi.rkt`'s top-level `(run)` parses the command-line, sees no command, and falls through to the usage-fallback `(display-usage) (exit 3)` branch — that 3 is exactly what the pkg-build log shows.

Tried first to move `(run)` inside `(module+ main ...)`, but `raco-commands` dispatches the registered module via `dynamic-require` (same as the `profile/raco`, `contract-profile/raco` pattern), which runs the top-level body but **not** submodules — so `raco pyffi` itself silently no-ops.

The correct fix is to keep `(run)` at the top level and tell `raco test` to skip the file via `test-omit-paths` in `pyffi-lib/pyffi/info.rkt`.

Verified locally:

- `raco test pyffi-lib/pyffi/` no longer touches `configure-pyffi.rkt` (grep on the test output returns 0 matches).
- `raco pyffi show` and `raco pyffi configure` still dispatch correctly via the existing `raco-commands` entry.

## Test plan

- [ ] `raco test pyffi-lib/pyffi/` — output contains no reference to `configure-pyffi.rkt`
- [ ] `raco pyffi show` — prints the current configuration
- [ ] `raco pyffi configure` — auto-detects `python3` and writes the preferences
- [ ] Next pkg-build cycle clears `pyffi-lib` from `test-fail`
