### PR TITLE
Fix numpy-in-venv loading; convert four demos into proper unit tests

### DIFF
--- a/pyffi-lib/pyffi/python-initialization.rkt
+++ b/pyffi-lib/pyffi/python-initialization.rkt
@@ -163,16 +163,27 @@
 
   (initialize-builtin-constants) ; uses `run`
 
-  
+  ;; Inject the venv's site-packages into sys.path here, while
+  ;; Python is up but no user-level imports have happened yet.
+  ;; Doing it later (e.g. inside post-initialize, where it used
+  ;; to live) is too late: any module imported between initialize
+  ;; and post-initialize — including numpy via initialize-numpy
+  ;; — would silently fail to find its venv-installed package
+  ;; because the venv path isn't on sys.path yet.
+  (inject-venv-path)
+
   ; We can't run the initialization thunks here.
   ; The Python modules are loaded yet.
   #;(run-initialization-thunks))
 
 
-(define (post-initialize)
-  (run-initialization-thunks)
-  ; Inject venv site-packages into sys.path when a venv was configured.
-  (define venv-pref (get-preference 'pyffi:venv (λ () #f)))
+;; Add the configured venv's site-packages directory to sys.path.
+;; No-op when the user has not configured a venv, or when the
+;; expected site-packages directory does not exist (e.g. the venv
+;; was built with a different Python minor version than
+;; pyffi:pyver records).
+(define (inject-venv-path)
+  (define venv-pref  (get-preference 'pyffi:venv  (λ () #f)))
   (define pyver-pref (get-preference 'pyffi:pyver (λ () "3.12")))
   (when venv-pref
     (define sitepkg (string-append venv-pref "/lib/python" pyver-pref "/site-packages"))
@@ -182,6 +193,9 @@
       (define sys-path    (PyObject_GetAttrString sys-mod "path"))
       (PyList_Append sys-path (PyUnicode_FromString sitepkg))
       (void))))
+
+(define (post-initialize)
+  (run-initialization-thunks))
 
 (define (finish-initialization)
   (run-initialization-thunks))

--- a/pyffi-tests/tests/test-exceptions.rkt
+++ b/pyffi-tests/tests/test-exceptions.rkt
@@ -1,12 +1,15 @@
 #lang racket
 
-(require pyffi)
-(initialize)                
+(require pyffi
+         rackunit)
+(initialize)
 (finish-initialization)
 
 (void (run* "def provoke0(baz=1): return 2/0"))
 (define provoke0 (get-fun 'provoke0))
-(provoke0)
 
-
-
+;; Calling provoke0 must surface ZeroDivisionError as the typed
+;; exn:fail:pyffi:python.  Assert it instead of letting the
+;; exception propagate to the top level (which would make raco
+;; test report the file as failing).
+(check-exn exn:fail:pyffi:python? (λ () (provoke0)))

--- a/pyffi-tests/tests/test-exn.rkt
+++ b/pyffi-tests/tests/test-exn.rkt
@@ -1,9 +1,15 @@
 #lang racket
 
+(require rackunit)
+
+;; A renamed procedure that raises a plain exn must surface the
+;; exn through the rename — the original message is preserved.
+;; Asserting it keeps this file usable under raco test instead of
+;; producing an unhandled raise at the top level.
 (define foo
   (let ()
     (define proc (λ () (raise (exn "hello" (current-continuation-marks)))))
     (procedure-rename proc 'bar)))
 
-(displayln (foo))
-
+(check-exn (λ (e) (and (exn? e) (string=? (exn-message e) "hello")))
+           foo)

--- a/pyffi-tests/tests/test-pyautogui.rkt
+++ b/pyffi-tests/tests/test-pyautogui.rkt
@@ -2,13 +2,20 @@
 (require pyffi)
 
 ;; Setup Python
-(initialize)                
+(initialize)
 (finish-initialization)
 
 
-;; Import `pyautogui`
-(import pyautogui)
+;; pyautogui is an optional Python dependency that also requires
+;; a graphical display.  Skip silently when it's not importable
+;; instead of failing the test suite for environments that don't
+;; have it.
+(define pyautogui-available?
+  (with-handlers ([exn:fail? (λ (e) #f)])
+    (run* "import pyautogui")
+    #t))
 
-;; Use it
-(pyautogui.position)
-(pyautogui.write "echo \"Hello World\" \n")
+(when pyautogui-available?
+  (run* "import pyautogui")
+  (run "pyautogui.position()")
+  (run "pyautogui.write('echo \"Hello World\" \\n')"))

--- a/pyffi-tests/tests/test-write-and-display.rkt
+++ b/pyffi-tests/tests/test-write-and-display.rkt
@@ -1,6 +1,9 @@
 #lang racket
 (require pyffi)
 
+(initialize)
+(finish-initialization)
+
 (define hw (string->pystring "Hello World"))
 
 (write   hw) (newline)


### PR DESCRIPTION
## Summary

- Move the venv site-packages injection from `post-initialize` to the
  end of `initialize`. The previous ordering ran the init-thunks
  before adding the venv path to `sys.path`, so any Racket binding
  whose init-thunk imported a venv-installed Python module silently
  failed. The most visible casualty was `test-numpy.rkt` (and the
  wider numpy test surface), which never reached `bool_` because
  numpy itself was never bound into `main`.

- Repair four test files that exited non-zero under `raco test` from
  the moment they were added — `test-exceptions.rkt` and
  `test-exn.rkt` were unhandled raises at the top level,
  `test-write-and-display.rkt` was missing `(initialize)`, and
  `test-pyautogui.rkt` blew up when the optional `pyautogui` package
  wasn't installed. Each becomes a proper assertion or a
  skip-when-unavailable.

## Testing

- [x] `raco test pyffi-tests/tests/` — 26 passed, 0 failures (was 8
      failures on `main`).
- [x] `test-numpy.rkt`, `test-numpy-misc.rkt`,
      `test-numpy-game-of-life.rkt`, and `test-auto-numpy.rkt` all
      pass with numpy 1.26.4 in a venv.
- [x] No callers of `post-initialize` need to change — it still runs
      the init-thunks; the venv injection is just no longer coupled
      to it.
